### PR TITLE
Use postfix_custom_main variable if defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This role configures postfix in a standard
 [null client](http://www.postfix.org/STANDARD_CONFIGURATION_README.html#null_client)
 mode.
 
+You can also override the configuration by defining postfix_custom_main variable. See defaults/main.yml for example.
+
 
 Requirements
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,19 @@ postfix_ipv4_only: True
 # By default mydomain will be ansible_fqdn minus the host part. If you
 # want to override that, set it here.
 # postfix_mydomain: "example.org"
+
+#
+# You can also override the whole configuration by defining
+# postfix_custom_main varible:
+# postfix_custom_main: |
+#  myorigin = $mydomain
+#  relayhost = smtp.$mydomain
+#  alias_maps = hash:/etc/aliases
+#  daemon_directory = /usr/libexec/postfix
+#  inet_interfaces = $myhostname, localhost
+#  inet_protocols = ipv4
+#  relay_domains =
+#  mynetworks = 127.0.0.0/8 10.0.0.0/24 $myhostname
+#  smtpd_recipient_restrictions = permit_mynetworks,
+#    check_recipient_access hash:/etc/postfix/recipient-access,
+#    reject

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -1,4 +1,7 @@
 # {{ ansible_managed }}
+{% if postfix_custom_main is defined %}
+{{ postfix_main }}
+{% else %}
 myhostname = {{ ansible_fqdn }}
 {% if postfix_mydomain is defined %}
 mydomain = {{ postfix_mydomain }}
@@ -12,3 +15,4 @@ inet_protocols = ipv4
 {% endif %}
 inet_interfaces = loopback-only
 mydestination =
+{% endif %}

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 {% if postfix_custom_main is defined %}
-{{ postfix_main }}
+{{ postfix_custom_main }}
 {% else %}
 myhostname = {{ ansible_fqdn }}
 {% if postfix_mydomain is defined %}


### PR DESCRIPTION
Use postfix_custom_main configuration variable if defined. Use like this in variables:

postfix_custom_main: |
  myorigin = $mydomain
  relayhost = smtp.$mydomain
  alias_maps = hash:/etc/aliases
  daemon_directory = /usr/libexec/postfix
  inet_interfaces = $myhostname, localhost
  inet_protocols = ipv4
  relay_domains =
  mynetworks = 127.0.0.0/8 10.0.0.0/24 $myhostname
  smtpd_recipient_restrictions = permit_mynetworks,
    check_recipient_access hash:/etc/postfix/recipient-access,
    reject